### PR TITLE
app: reduce the usage of THROW

### DIFF
--- a/app/src/approve.c
+++ b/app/src/approve.c
@@ -56,7 +56,10 @@ static approve_callback_ty approve_cb_;
 static void touch_okay() {
   uint8_t tx = 0;
   BEGIN_TRY {
-    TRY { approve_cb_(&tx); }
+    TRY {
+      const uint16_t ret = approve_cb_(&tx);
+      THROW(ret);
+    }
     CATCH(EXCEPTION_IO_RESET) { THROW(EXCEPTION_IO_RESET); }
     CATCH_OTHER(e) {
       uint16_t sw;

--- a/app/src/approve.h
+++ b/app/src/approve.h
@@ -6,7 +6,7 @@
 extern char ApproveLine1[32];
 extern char ApproveLine2[32];
 
-typedef void (*approve_callback_ty)(uint8_t *);
+typedef uint16_t (*approve_callback_ty)(uint8_t *);
 void ui_approval(approve_callback_ty cb);
 
 #endif

--- a/app/src/instrs.h
+++ b/app/src/instrs.h
@@ -12,7 +12,7 @@ enum AppInstrs {
   INS_LAST
 };
 
-typedef void (*handleInstrFunTy)(
+typedef uint16_t (*handleInstrFunTy)(
     // p1,p2,data,datalen
     uint8_t, uint8_t, uint8_t const *, uint8_t,
     // flags,tx

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -50,8 +50,10 @@ static void handleApdu(volatile unsigned int *flags,
       if (len > (IO_APDU_BUFFER_SIZE - OFFSET_CDATA)) {
         THROW(INVALID_PARAMETER);
       }
-      F(G_io_apdu_buffer[OFFSET_P1], G_io_apdu_buffer[OFFSET_P2],
-        &G_io_apdu_buffer[OFFSET_CDATA], len, flags, tx);
+      const uint16_t ret =
+          F(G_io_apdu_buffer[OFFSET_P1], G_io_apdu_buffer[OFFSET_P2],
+            &G_io_apdu_buffer[OFFSET_CDATA], len, flags, tx);
+      THROW(ret);
     }
     CATCH(EXCEPTION_IO_RESET) { THROW(EXCEPTION_IO_RESET); }
     CATCH_OTHER(e) {


### PR DESCRIPTION
This allows easier fuzzing/testing of the instruction handlers.